### PR TITLE
fix: tweak scroll-margin properties

### DIFF
--- a/src/styles/basic.css
+++ b/src/styles/basic.css
@@ -94,7 +94,9 @@
    * Base size set to 16px
    */
   html {
-    font: 100%/1.5 'Atak', sans-serif;
+    font:
+      100%/1.5 'Atak',
+      sans-serif;
     font-weight: 300;
     text-size-adjust: 100%;
   }
@@ -237,7 +239,7 @@
 
   @media (min-width: 30em) {
     :target {
-      scroll-margin-top: 5.2em;
+      scroll-margin-block-start: 5.2em;
     }
   }
 }


### PR DESCRIPTION
Steps to reproduce:

1. Click on any speaker in the schedule
2. `:target` element should offset below header when scrolled to