### PR TITLE
fix(#622): fix narrow nav in Edge on Android

### DIFF
--- a/src/lib/components/mainNav.svelte
+++ b/src/lib/components/mainNav.svelte
@@ -44,6 +44,8 @@
 
 <style>
   nav {
+    flex: 1;
+
     display: flex;
     justify-content: center;
     align-content: center;


### PR DESCRIPTION
Fixes #622
